### PR TITLE
Add New Projects: Piano Smasher and Winamp Music Visualiser

### DIFF
--- a/assets/curiosities.json
+++ b/assets/curiosities.json
@@ -48,6 +48,22 @@
     "tags": ["toys"]
   },
   {
+    "title": "Piano Smasher Rhythm Game",
+    "url": "https://piano-smasher.cosine.show/",
+    "description": "Upload an mp3 and play it!",
+    "screenshotUrl": "https://screenshot.cosine.show/?url=https://piano-smasher.cosine.show",
+    "author": "curtisahuang",
+    "tags": ["games", "music"]
+  },
+  {
+    "title": "winamp music visualiser",
+    "url": "https://music-visualiser-winamp.cosine.page/",
+    "description": "Share a tab's audio with this page to see some retro visualisations!",
+    "screenshotUrl": "https://screenshot.cosine.show/?url=https://music-visualiser-winamp.cosine.page/",
+    "author": "curtisahuang",
+    "tags": ["music"]
+  },
+  {
     "title": "14 Days Until Christmas Game",
     "url": "https://14-days-until-christmas-game.cosine.show/",
     "description": "A dating simulator with music and choices that determine whether you can get a date by Christmas!",


### PR DESCRIPTION
This pull request adds two new projects to the curiosities list: the "Piano Smasher Rhythm Game" and the "Winamp Music Visualiser". 

1. **Piano Smasher Rhythm Game**: Users can upload an mp3 file and play along with it. 
   - **URL**: [Piano Smasher](https://piano-smasher.cosine.show/)
   - **Author**: curtisahuang
   - **Tags**: games, music
   - **Screenshot**: [View Screenshot](https://screenshot.cosine.show/?url=https://piano-smasher.cosine.show)

2. **Winamp Music Visualiser**: Users can share a tab's audio to see retro visualizations, creating a nostalgic audio experience.
   - **URL**: [Winamp Music Visualiser](https://music-visualiser-winamp.cosine.page/)
   - **Author**: curtisahuang
   - **Tags**: music
   - **Screenshot**: [View Screenshot](https://screenshot.cosine.show/?url=https://music-visualiser-winamp.cosine.page/)

These additions will enhance the diversity of projects available, particularly in the music and gaming categories.

---

> This pull request was co-created with Cosine Genie

Original Task: [curtiss-cabinet-of-curiosities/rxqc0iw41cwf](https://cosine.wtf/cosine-stg/curtiss-cabinet-of-curiosities/task/rxqc0iw41cwf)
Author: Curtis Huang
